### PR TITLE
Add class property to backtrace lines

### DIFF
--- a/exceptions/v1/notices.json
+++ b/exceptions/v1/notices.json
@@ -83,6 +83,10 @@
                 "id": "#/properties/notifier/error/backtrace/0/method",
                 "type": "string"
               },
+              "class": {
+                "id": "#/properties/notifier/error/backtrace/0/class",
+                "type": "string"
+              },
               "args": {
                 "id": "#/properties/notifier/error/backtrace/0/args",
                 "type": "array",
@@ -149,6 +153,10 @@
                     },
                     "method": {
                       "id": "#/properties/notifier/error/causes/0/backtrace/0/method",
+                      "type": "string"
+                    },
+                    "class": {
+                      "id": "#/properties/notifier/error/causes/0/backtrace/0/class",
                       "type": "string"
                     },
                     "context": {


### PR DESCRIPTION
This is to support a new PHP feature, since PHP includes the class name in addition to the method name in some stack traces. See https://github.com/honeybadger-io/honeybadger-php/issues/61