### PR TITLE
Add correlation_context/request_id

### DIFF
--- a/exceptions/v1/notices.json
+++ b/exceptions/v1/notices.json
@@ -3,6 +3,17 @@
   "id": "exceptions/v1/notices.json",
   "type": "object",
   "properties": {
+    "correlation_context": {
+      "id": "#/properties/correlation_context",
+      "type": "object",
+      "properties": {
+        "request_id": {
+          "id": "#/properties/correlation_context/request_id",
+          "description": "The request id that this error is associated with",
+          "type": "string"
+        }
+      }
+    },
     "breadcrumbs": {
       "id": "#/properties/breadcrumbs",
       "type": "object",


### PR DESCRIPTION
This adds an optional root `correlation_context` object, which currently only contains an optional `request_id` string.