### PR TITLE
Add volume_spike event schema

### DIFF
--- a/data/v1/events/volume_spike.json
+++ b/data/v1/events/volume_spike.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "volume_spike.json#",
+  "type": "object",
+  "properties": {
+    "event": {
+      "id": "event",
+      "type": "string"
+    },
+    "message": {
+      "id": "message",
+      "type": "string"
+    },
+    "project": {"$ref": "../project.json#"},
+    "volume_spike": {
+      "id": "volume_spike",
+      "type": "object",
+      "properties": {
+        "observed": {
+          "id": "observed",
+          "type": "integer"
+        },
+        "baseline_median": {
+          "id": "baseline_median",
+          "type": "number"
+        },
+        "factor": {
+          "id": "factor",
+          "type": "number"
+        },
+        "z_score": {
+          "id": "z_score",
+          "type": "number"
+        },
+        "window_minutes": {
+          "id": "window_minutes",
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "observed",
+        "baseline_median",
+        "factor",
+        "z_score",
+        "window_minutes"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "event",
+    "message",
+    "project",
+    "volume_spike"
+  ]
+}

--- a/data/v2/events/volume_spike.json
+++ b/data/v2/events/volume_spike.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "volume_spike.json#",
+  "type": "object",
+  "properties": {
+    "event": {
+      "id": "event",
+      "type": "string"
+    },
+    "message": {
+      "id": "message",
+      "type": "string"
+    },
+    "project": {"$ref": "../project.json#"},
+    "volume_spike": {
+      "id": "volume_spike",
+      "type": "object",
+      "properties": {
+        "observed": {
+          "id": "observed",
+          "type": "integer"
+        },
+        "baseline_median": {
+          "id": "baseline_median",
+          "type": "number"
+        },
+        "factor": {
+          "id": "factor",
+          "type": "number"
+        },
+        "z_score": {
+          "id": "z_score",
+          "type": "number"
+        },
+        "window_minutes": {
+          "id": "window_minutes",
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "observed",
+        "baseline_median",
+        "factor",
+        "z_score",
+        "window_minutes"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "event",
+    "message",
+    "project",
+    "volume_spike"
+  ]
+}


### PR DESCRIPTION
Adds JSON schemas for the new project-wide error-volume spike webhook event (`:volume_spike`) introduced in honeybadger-io/honeybadger#6248, for both the v1 and v2 Data Access APIs. The payload carries the event subject as a `project` ref plus a `volume_spike` object with the detector facts (`observed`, `baseline_median`, `factor`, `z_score`, `window_minutes`), mirroring the existing `occurred`/`outage` event schemas. The schemas are served automatically since `public/data` symlinks to `data/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)